### PR TITLE
Updates to Voice list in settings: removing duplicates, other languages

### DIFF
--- a/Enchanted/Extensions/AVSpeechSynthesisVoice+Extension.swift
+++ b/Enchanted/Extensions/AVSpeechSynthesisVoice+Extension.swift
@@ -10,20 +10,23 @@ import AVFoundation
 
 extension AVSpeechSynthesisVoice {
     var prettyName: String {
-        let name = self.name
-        if name.lowercased().contains("default") || name.lowercased().contains("premium") || name.lowercased().contains("enhanced") {
-            return name
-        }
-        
-        let qualityString = {
-            switch self.quality.rawValue {
-            case 1: return "Default"
-            case 2: return "Enhanced"
-            case 3: return "Premium"
-            default: return "Unknown"
-            }
-        }()
+        guard quality == .enhanced || quality == .premium else { return name }
+
+        let qualityString = quality.displayString
+        guard !name.lowercased().contains(qualityString.lowercased()) else { return name }
         
         return "\(name) (\(qualityString))"
+    }
+}
+
+extension AVSpeechSynthesisVoiceQuality {
+    var displayString: String {
+        switch self {
+        case .default: return "Default"
+        case .enhanced: return "Enhanced"
+        case .premium: return "Premium"
+        @unknown default:
+            return "Unknown"
+        }
     }
 }

--- a/Enchanted/Services/SpeechService.swift
+++ b/Enchanted/Services/SpeechService.swift
@@ -31,35 +31,41 @@ class SpeechSynthesizerDelegate: NSObject, AVSpeechSynthesizerDelegate {
     static let shared = SpeechSynthesizer()
     private let synthesizer = AVSpeechSynthesizer()
     private let delegate = SpeechSynthesizerDelegate()
-    
+
     @Published var isSpeaking = false
     @Published var voices: [AVSpeechSynthesisVoice] = []
-    
+
     override init() {
         super.init()
         synthesizer.delegate = delegate
         fetchVoices()
     }
-    
+
+    static func systemDefaultVoiceIdentifier() -> String {
+        // Type system says this might be nil, but documentation says we'll receive
+        // the default voice for the system's language & region
+        return AVSpeechSynthesisVoice(language: nil)?.identifier ?? ""
+    }
+
     func getVoiceIdentifier() -> String? {
         let voiceIdentifier = UserDefaults.standard.string(forKey: "voiceIdentifier")
         if let voice = voices.first(where: {$0.identifier == voiceIdentifier}) {
             return voice.identifier
         }
-        
-        return voices.first?.identifier
+
+        return SpeechSynthesizer.systemDefaultVoiceIdentifier()
     }
-    
+
     var lastCancelation: (()->Void)? = {}
-    
+
     func speak(text: String, onFinished: @escaping () -> Void = {}) async {
         guard let voiceIdentifier = getVoiceIdentifier() else {
             print("could not find identifier")
             return
         }
-        
+
         print("selected", voiceIdentifier)
-        
+
 #if os(iOS)
         let audioSession = AVAudioSession()
         do {

--- a/Enchanted/Services/SpeechService.swift
+++ b/Enchanted/Services/SpeechService.swift
@@ -13,15 +13,15 @@ import SwiftUI
 class SpeechSynthesizerDelegate: NSObject, AVSpeechSynthesizerDelegate {
     var onSpeechFinished: (() -> Void)?
     var onSpeechStart: (() -> Void)?
-    
+
     func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
         onSpeechFinished?()
     }
-    
+
     func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didStart utterance: AVSpeechUtterance) {
         onSpeechStart?()
     }
-    
+
     func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didReceiveError error: Error, for utterance: AVSpeechUtterance, at characterIndex: UInt) {
         print("Speech synthesis error: \(error)")
     }
@@ -69,7 +69,7 @@ class SpeechSynthesizerDelegate: NSObject, AVSpeechSynthesizerDelegate {
             print("❓", error.localizedDescription)
         }
 #endif
-        
+
         lastCancelation = onFinished
         delegate.onSpeechFinished = {
             withAnimation {
@@ -82,18 +82,18 @@ class SpeechSynthesizerDelegate: NSObject, AVSpeechSynthesizerDelegate {
                 self.isSpeaking = true
             }
         }
-        
+
         let utterance = AVSpeechUtterance(string: text)
         utterance.voice = AVSpeechSynthesisVoice(identifier: voiceIdentifier)
         utterance.rate = 0.5
         synthesizer.speak(utterance)
-        
+
         let voices = AVSpeechSynthesisVoice.speechVoices()
         voices.forEach { voice in
             print("\(voice.identifier) - \(voice.name)")
         }
     }
-    
+
     func stopSpeaking() async {
         withAnimation {
             isSpeaking = false
@@ -101,19 +101,33 @@ class SpeechSynthesizerDelegate: NSObject, AVSpeechSynthesizerDelegate {
         lastCancelation?()
         synthesizer.stopSpeaking(at: .immediate)
     }
-    
-    
+
+
     func fetchVoices() {
-        let voices = AVSpeechSynthesisVoice.speechVoices().sorted { (firstVoice: AVSpeechSynthesisVoice, secondVoice: AVSpeechSynthesisVoice) -> Bool in
-            return firstVoice.quality.rawValue > secondVoice.quality.rawValue
-        }
-        
+        let currentLanguage: String = AVSpeechSynthesisVoice.currentLanguageCode()
+        let voicesByLanguage = Dictionary(grouping: AVSpeechSynthesisVoice.speechVoices(), by: \.language)
+        // Filter the list to only include voices for the current language
+        // example language codes: en-US, en-GB, fr-FR
+            .filter { $0.key.prefix(2) == currentLanguage.prefix(2) }
+
+        let voices = voicesByLanguage.values.reduce(
+            // Start with all voices that exactly match current language & locale
+            into: voicesByLanguage[currentLanguage, default: []]) { result, voices in
+                // add one instance of other voices that match the language, uniquing by name & quality
+                for voice in voices {
+                    if !result.contains(where: { otherVoice in otherVoice.name == voice.name && otherVoice.quality == voice.quality }) {
+                        result.append(voice)
+                    }
+                }
+            }
+            .sorted { $0.prettyName.localizedStandardCompare($1.prettyName) == .orderedAscending }
+
         /// prevent state refresh if there are no new elements
         let diff = self.voices.elementsEqual(voices, by: { $0.identifier == $1.identifier })
         if diff {
             return
         }
-        
+
         DispatchQueue.main.async {
             self.voices = voices
         }

--- a/Enchanted/UI/Shared/Settings/Settings.swift
+++ b/Enchanted/UI/Shared/Settings/Settings.swift
@@ -21,8 +21,8 @@ struct Settings: View {
     @AppStorage("ollamaBearerToken") private var ollamaBearerToken: String = ""
     @AppStorage("appUserInitials") private var appUserInitials: String = ""
     @AppStorage("pingInterval") private var pingInterval: String = "5"
-    @AppStorage("voiceIdentifier") private var voiceIdentifier: String = ""
-    
+    @AppStorage("voiceIdentifier") private var voiceIdentifier: String = SpeechSynthesizer.systemDefaultVoiceIdentifier()
+
     @StateObject private var speechSynthesiser = SpeechSynthesizer.shared
     
     @Environment(\.presentationMode) var presentationMode


### PR DESCRIPTION
This might be a partial fix for #149. There are other ideas in that issue that I haven't looked at.

This PR does the following: 

* Add all of the voices that exactly match the current language & region
* Add any voices that match the current language, from a different region, that aren't already in the list.
* Filters out voices that are for other languages
* Filters out duplicate entries
* Only show voice "quality" if it's non-Default. Should be more clear what's happening.
* This PR also uses the system default voice by default, and only uses the in-app voice list if the user has specifically chosen & saved a voice in Enchanted.

## After:
<img width="492" alt="Screenshot 2025-02-04 at 6 24 17 PM" src="https://github.com/user-attachments/assets/5dba0115-d68b-482f-8eb6-7763ae56c836" />

## Before (truncated Picker list, it's 3-4x longer):
<img width="607" alt="Screenshot 2025-02-04 at 7 28 43 PM" src="https://github.com/user-attachments/assets/09155ad1-b0c1-431c-ac3f-98fc2a84f9ce" />


Side note:
in order to build & test, I had to do something with `swift-markdown-ui`. I didn't see #154 / #155 , but made a similar change locally.